### PR TITLE
[Config] Add sheduler Containerfile config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,22 @@
+# Python base
+FROM python:3.13-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Update package list
+RUN apt-get update && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy your application code
+COPY . .
+
+# Set entry point to run your scheduler app (scheduler.py)
+CMD ["python", "scheduler.py"]

--- a/container-compose.yaml
+++ b/container-compose.yaml
@@ -36,6 +36,17 @@ services:
     networks:
       - opensearch-net
 
+  scheduler:
+    image: scheduler-app:latest
+    container_name: scheduler
+    volumes:
+      - scheduler-data:/usr/share/scheduler:Z
+    depends_on:
+      - opensearch
+      - dashboards
+    networks:
+      - opensearch-net
+
 volumes:
   opensearch-data:
     driver: local
@@ -49,6 +60,13 @@ volumes:
     driver_opts:
       type: none
       device: /data/dashboards
+      o: bind
+
+  scheduler-data:
+    driver: local
+    driver_opts:
+      type: none
+      device: /data/scheduler
       o: bind
 
 networks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 apscheduler
 docopt
-drain3
+drain3==0.9.11
 opensearch-py
 pytz
 requests

--- a/scheduler.py
+++ b/scheduler.py
@@ -9,7 +9,7 @@ from apscheduler.triggers.cron import CronTrigger
 from run import main as run_main
 
 # Set scheduler configs
-CONFIG_FILE = "/data/scheduler/config.cfg"
+CONFIG_FILE = "/usr/share/scheduler/config.cfg"
 SKIP_DRAIN3_TEMPLATES = False
 USER = "teuthology"
 TIMEZONE = "UTC"


### PR DESCRIPTION
Add `Containerfile` to create image with scheduler script which includes -

1. Installation of required packages.
2. Map config directory to `/usr/share/scheduler`.
3. Execution of scheduler.py
4. Will trigger run.py after every 4 hours. 
5. Compose to deploy along with OpenSearch containers.

Steps to create and deploy container -
1. Build image 
    `$ podman build -t scheduler-app:latest .`
2. Test image
    `$ podman run -d -v <config-path>:/usr/share/scheduler:Z scheduler-app:latest`