### PR TITLE
Add optional user filter for report and query data

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -37,9 +37,11 @@ This document deploys opensearch for processing test run results data from paddl
     ```sh
     cat <<'EOF' > .env
     OPENSEARCH_INITIAL_ADMIN_PASSWORD='<passwd>'
-    APP_ARGS='--config /usr/share/config.cfg --sha1-path /usr/share/sha1 --user teuthology'
+    APP_ARGS='--config /usr/share/config.cfg --sha1-path /usr/share/sha1 --user cephuser'
     EOF
     ```
+    - `--user` filters both task runs and scheduled report data to that user (e.g. `cephuser`). Omit or change as needed for your environment.
+    - Add `--use-paddle` to have reports fetch data from Paddle instead of OpenSearch.
 
 6. **Start the services**
     ```sh

--- a/report.py
+++ b/report.py
@@ -8,6 +8,7 @@ Usage:
               --end-date <end-date> 
               --email-address <email> 
               [--sha-id <sha-id>]
+              [--user <user>]
               [--use-paddle]
               [--log-level <LOG>]
               [--log-path <LOG_PATH>]
@@ -20,6 +21,7 @@ Options:
     --email-address <email>       Email address to send the report to (or
                                   comma-separated list of emails).
     --sha-id <sha-id>             SHA ID to filter results.
+    --user <user>                 User to filter report data (e.g. cephuser).
     --use-paddle                  Fetch report data from Paddle instead of OpenSearch.
     --log-level <LOG>             Log level for log utility
     --log-path <LOG_PATH>         Log file path for log utility
@@ -51,12 +53,16 @@ def main(args):
     # get sha_id if provided
     sha_id = args.get("--sha-id")
 
+    # get user if provided (e.g. cephuser - filters report to that user only)
+    user = args.get("--user")
+
     # check if use_paddle flag is set
     use_paddle = args.get("--use-paddle", False)
 
     # Call main function
     publish_report(
-        config_file, start_date, end_date, branch, address, sha_id, use_paddle=use_paddle
+        config_file, start_date, end_date, branch, address, sha_id, 
+        use_paddle=use_paddle, user=user
     )
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -63,7 +63,7 @@ def start_task_scheduler(config_file, user, skip_drain3_templates, cron_expr, lo
     return scheduler
 
 
-def start_report_scheduler(config_file, cron_dir, cron_expr, log_level=None, log_path=None, use_paddle=False):
+def start_report_scheduler(config_file, cron_dir, cron_expr, user=None, log_level=None, log_path=None, use_paddle=False):
     """Start report scheduler"""
     # Scheduler
     scheduler = BackgroundScheduler()
@@ -74,7 +74,7 @@ def start_report_scheduler(config_file, cron_dir, cron_expr, log_level=None, log
     # Add job for report
     scheduler.add_job(
         run_report,
-        args = [config_file, cron_dir, log_level, log_path, use_paddle],
+        args=[config_file, cron_dir, log_level, log_path, use_paddle, user],
         trigger=trigger,
         max_instances=MAX_INSTANCES,
         misfire_grace_time=MISFIRE_GRACE_SECONDS,
@@ -113,7 +113,7 @@ def schedule(config_file, sha1_path, user, skip_drain3_templates, log_level=None
         config_file, user, skip_drain3_templates, _config["cron_task"], log_level, log_path
     )
     report_scheduler = start_report_scheduler(
-        config_file, sha1_path, _config["cron_report"], log_level, log_path, use_paddle
+        config_file, sha1_path, _config["cron_report"], user, log_level, log_path, use_paddle
     )
 
     # Create shutdown handler for graceful termination


### PR DESCRIPTION
### Summary
Adds an optional --user filter so reports and scheduled jobs can be limited to a single user (e.g. ubuntu). Filtering works for both OpenSearch and Paddle backends.